### PR TITLE
coopersmi/coo-76-fix-category-to-categories

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -335,7 +335,7 @@ export default class GranolaPlugin extends Plugin {
 			let frontmatter = 
 `---
 title: "${title.replace(/"/g, '\\"')}"
-category: "[[Meetings]]"
+categories: "[[Meetings]]"
 type: 
 created_at: ${formatDateWithOffset(doc.created_at)}
 `;


### PR DESCRIPTION
## Summary
- use `categories` key in note frontmatter instead of `category`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893a8d7ebbc832e8c9ebe103027a42f