### PR TITLE
docs: clarify new token command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,18 @@ This plugin syncs your [Granola](https://granola.ai) notes to your Obsidian vaul
 ## Setup
 
 1. Find your Granola API token using one of these methods:
+
+   > **Note:** Granola recently switched from Cognito to WorkOS for authentication. The old `cat ~/Library/Application Support/Granola/supabase.json` command shows a stale `cognito_tokens` entry. Use the following `jq` command to extract whichever token is currently valid.
+
    
-   **Method 1: Using Terminal**
+   **Method 1: Using Terminal (new command)**
+   ```bash
+   FILE="$HOME/Library/Application Support/Granola/supabase.json"
+   jq -r ' (try (.workos_tokens | fromjson | .access_token) // empty) as $w
+     | (try (.cognito_tokens | fromjson | .access_token) // empty) as $c
+     | if ($w|length)>0 then $w else $c end' "$FILE"
    ```
-   cat ~/Library/Application\ Support/Granola/supabase.json
-   ```
-   Find the `cognito_tokens` JSON string, and extract the `access_token` value.
+   This command prints your current Granola access token. It prefers the new `workos_tokens` entry and falls back to the older `cognito_tokens` value if needed.
    
    **Method 2: Using Developer Tools**
    - Open Granola app
@@ -44,8 +50,8 @@ This plugin syncs your [Granola](https://granola.ai) notes to your Obsidian vaul
    - Copy the token part
 
    **Note about API token expiration:**
-   Granola API tokens typically expire every 1-7 days. If you see a 401 authentication error when syncing, 
-   you'll need to generate a new token using one of the methods above and update it in your plugin settings.
+   Granola API tokens expire regularly (often within a day). If you see a 401 authentication error when syncing,
+   run the command above again to obtain a fresh token and update it in your plugin settings.
 
 2. In Obsidian, go to Settings → Granola Notes Sync
 3. Paste your API token in the "API Token" field

--- a/main.ts
+++ b/main.ts
@@ -660,23 +660,26 @@ class GranolaSettingTab extends PluginSettingTab {
 
 		containerEl.createEl('h3', { text: 'How to find your API token' });
 		const instructions = containerEl.createEl('div');
-		instructions.innerHTML = `
-			<p>To find your Granola API token:</p>
-			<ol>
-				<li>Open terminal and run: <code>cat ~/Library/Application\\ Support/Granola/supabase.json</code></li>
-				<li>Find the JSON string in <code>cognito_tokens</code></li>
-				<li>Copy the <code>access_token</code> value</li>
-			</ol>
-			<p>Or, if you have developer tools:</p>
-			<ol>
-				<li>Open Granola app</li>
-				<li>Open developer tools (View → Developer → Toggle Developer Tools)</li>
-				<li>Go to Network tab</li>
-				<li>Look for requests to <code>api.granola.ai</code></li>
-				<li>Find the Authorization header with format <code>Bearer &lt;token&gt;</code></li>
-				<li>Copy the token part</li>
-			</ol>
-			<p><strong>Important:</strong> Granola API tokens expire periodically. If you see a 401 authentication error, you'll need to get a fresh token using the steps above.</p>
-		`;
+                instructions.innerHTML = `
+                        <p>To find your Granola API token:</p>
+                        <ol>
+                                <li>Run the following in your terminal to print your current token:</li>
+                                <pre><code>FILE="$HOME/Library/Application Support/Granola/supabase.json"
+jq -r ' (try (.workos_tokens | fromjson | .access_token) // empty) as $w
+  | (try (.cognito_tokens | fromjson | .access_token) // empty) as $c
+  | if ($w|length)>0 then $w else $c end' "$FILE"</code></pre>
+                                <li>Copy the printed token</li>
+                        </ol>
+                        <p>Or, if you have developer tools:</p>
+                        <ol>
+                                <li>Open Granola app</li>
+                                <li>Open developer tools (View → Developer → Toggle Developer Tools)</li>
+                                <li>Go to Network tab</li>
+                                <li>Look for requests to <code>api.granola.ai</code></li>
+                                <li>Find the Authorization header with format <code>Bearer &lt;token&gt;</code></li>
+                                <li>Copy the token part</li>
+                        </ol>
+                        <p><strong>Important:</strong> Granola API tokens expire regularly. If you see a 401 authentication error, run the command above again to obtain a fresh token.</p>
+                `;
 	}
 }


### PR DESCRIPTION
## Summary
- highlight WorkOS transition and that old `cat` command is stale
- label terminal example as the new way to retrieve a fresh token

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af296049d8832ebffbb75118ca880d